### PR TITLE
Add missing '}' in dependency

### DIFF
--- a/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
+++ b/docs/userguide/src/en/bpmn/ch05a-Spring-Boot.adoc
@@ -371,7 +371,7 @@ To add JPA support for Flowable in Spring Boot, add following dependency:
 <dependency>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-data-jpa</artifactId>
-    <version>${spring-boot.version</version>
+    <version>${spring-boot.version}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Add missing '}' in spring boot dependency in JPA support section

#### Check List:
* Unit tests: NO
* Documentation: YES
